### PR TITLE
add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{ "name" : "browscap"
+, "description" : "PHP's get_browser/browscap.ini for Node"
+, "version" : "0.1.0"
+, "author" : "Dan Grossman"
+, "repository" :
+  { "type" : "git"
+  , "url" : "http://github.com/dangrossman/node-browscap.git"
+  }
+, "bugs" :
+  { "web" : "http://github.com/dangrossman/node-browscap/issues"
+  }
+, "bin" : { "browscap" : "./browscap.js" }
+, "main" : "browscap"
+, "engines" : { "node" : ">=0.2.0" }
+, "licenses" :
+  [ { "type" : "MIT"
+    , "url" : "http://github.com/dangrossman/node-browscap/README.markdown"
+    }
+  ]
+}


### PR DESCRIPTION
Just look through it to see that the information is correct. Just note that the name should be 'browscap' inside npm, because names containing 'node' or 'js' are discouraged.

If you have npm installed you can then run `npm publish http://github.com/dangrossman/node-browscap/tarball/master` to publish it, after you've committed this. Also remember to update package.json with a new version and republish when appropriate. :)

If you want to, I can publish it for you when you've committed, just tell me here.
