### PR TITLE
Quote Bugfix

### DIFF
--- a/browscap.js
+++ b/browscap.js
@@ -47,7 +47,7 @@ function parse(filename) {
           , name = parts[0]
           , value = parts[1]
         
-        if (name == 'Browser' && value[0] == '"' && value.slice(-1) == '"') {
+        if (value[0] == '"' && value.slice(-1) == '"') {
           value = value.slice(1, -1)
         }
         

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name" : "browscap"
 , "description" : "PHP's get_browser/browscap.ini for Node"
-, "version" : "0.1.3"
+, "version" : "0.1.4"
 , "author" : "Dan Grossman"
 , "contributors" :
   [ "Tor Valamo <tor.valamo@gmail.com> (http://github.com/torvalamo)"


### PR DESCRIPTION
I have removed the requirement for the property to be "browser" when attempting to remove quotes from the value string.
