### PR TITLE
Skip invalid regular expression without breaking the parser

### DIFF
--- a/browscap.js
+++ b/browscap.js
@@ -28,20 +28,24 @@ function parse(filename) {
         var pattern = line.slice(1, -1)
         
         // Convert the pattern into a proper regex
-        current = {
-          __regex__: new RegExp('^'
-            + pattern.replace(/\./g, '\\.')
-                     .replace(/\(/g, '\\(')
-                     .replace(/\)/g, '\\)')
-                     .replace(/\//g, '\\/')
-                     .replace(/\-/g, '\\-')
-                     .replace(/\*/g, '.*')
-                     .replace(/\?/g, '.?')
-            + '$')
+        try {
+          current = {
+              __regex__: new RegExp('^'
+              + pattern.replace(/\./g, '\\.')
+                  .replace(/\(/g, '\\(')
+                  .replace(/\)/g, '\\)')
+                  .replace(/\//g, '\\/')
+                  .replace(/\-/g, '\\-')
+                  .replace(/\*/g, '.*')
+                  .replace(/\?/g, '.?')
+                  .replace(/\+/g, '\\+')
+              + '$')
+          }
+          browserArray.push(current) // Push new browser object onto array
+          patternIndex.push(pattern) // Push pattern onto pattern index
+        } catch (error) {
+          current = {}
         }
-        
-        browserArray.push(current) // Push new browser object onto array
-        patternIndex.push(pattern) // Push pattern onto pattern index
       } else {
         var parts = line.split('=')
           , name = parts[0]


### PR DESCRIPTION
Some patterns (like an unescaped `+` in the browscap) can break the parsing (`*+` will end up as something like `/.*+/`)
As a quick fix, I decided to skip any RegEx parsing error.

The raw `+` should be escaped anyway, so I added this as well.
